### PR TITLE
Add GitHub Actions CI/release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '.github/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'NOTICE'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '.github/**'
+      - 'README.md'
+      - 'LICENSE'
+      - 'NOTICE'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build and test
+        run: ./mvnw -q package
+
+  snapshot:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build
+        run: ./mvnw -q package -DskipTests
+
+      - name: Collect artifacts
+        id: artifacts
+        run: |
+          JAR=$(ls java-buildpack-client-certificate-mapper/target/java-buildpack-client-certificate-mapper-*SNAPSHOT.jar \
+                | grep -v 'sources\|javadoc\|original' | head -1)
+          SOURCES=$(ls java-buildpack-client-certificate-mapper/target/java-buildpack-client-certificate-mapper-*SNAPSHOT-sources.jar \
+                    | head -1)
+          echo "jar=$JAR" >> $GITHUB_OUTPUT
+          echo "sources=$SOURCES" >> $GITHUB_OUTPUT
+
+      - name: Recreate rolling snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          gh release delete snapshot --yes 2>/dev/null || true
+          git push origin :refs/tags/snapshot 2>/dev/null || true
+          gh release create snapshot \
+            --prerelease \
+            --title "Latest SNAPSHOT ($VERSION)" \
+            --notes "Automatically published on every push to \`main\`. Always reflects the latest snapshot build." \
+            "${{ steps.artifacts.outputs.jar }}" \
+            "${{ steps.artifacts.outputs.sources }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g. 2.0.2)'
+        required: true
+      next_snapshot_version:
+        description: 'Next development version (e.g. 2.0.3-SNAPSHOT)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set release version
+        run: ./mvnw versions:set -DnewVersion=${{ inputs.release_version }} -DgenerateBackupPoms=false
+
+      - name: Commit and tag release
+        run: |
+          git add .
+          git commit --message "v${{ inputs.release_version }} Release"
+          git tag v${{ inputs.release_version }}
+
+      - name: Build release
+        run: ./mvnw -q package -DskipTests
+
+      - name: Collect artifacts
+        id: artifacts
+        run: |
+          JAR=$(ls java-buildpack-client-certificate-mapper/target/java-buildpack-client-certificate-mapper-${{ inputs.release_version }}.jar \
+                | grep -v 'sources\|javadoc\|original' | head -1)
+          SOURCES=$(ls java-buildpack-client-certificate-mapper/target/java-buildpack-client-certificate-mapper-${{ inputs.release_version }}-sources.jar \
+                    | head -1)
+          echo "jar=$JAR" >> $GITHUB_OUTPUT
+          echo "sources=$SOURCES" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ inputs.release_version }} \
+            --title "v${{ inputs.release_version }}" \
+            --generate-notes \
+            "${{ steps.artifacts.outputs.jar }}" \
+            "${{ steps.artifacts.outputs.sources }}"
+
+      - name: Set next snapshot version
+        run: ./mvnw versions:set -DnewVersion=${{ inputs.next_snapshot_version }} -DgenerateBackupPoms=false
+
+      - name: Commit next snapshot version
+        run: |
+          git add .
+          git commit --message "v${{ inputs.next_snapshot_version }} Development"
+
+      - name: Push commits and tag
+        run: |
+          git push origin main
+          git push origin v${{ inputs.release_version }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 # Java Buildpack Client Certificate Mapper
 
-| Job | Status
-| --- | ------
-| `unit-test-7` | [![unit-test-master](https://java-experience.ci.springapps.io/api/v1/teams/java-experience/pipelines/client-certificate-mapper/jobs/unit-test-7/badge)](https://java-experience.ci.springapps.io/teams/java-experience/pipelines/client-certificate-mapper/jobs/unit-test-7)
-| `unit-test-8` | [![unit-test-master](https://java-experience.ci.springapps.io/api/v1/teams/java-experience/pipelines/client-certificate-mapper/jobs/unit-test-8/badge)](https://java-experience.ci.springapps.io/teams/java-experience/pipelines/client-certificate-mapper/jobs/unit-test-8)
-| `deploy` | [![deploy-master](https://java-experience.ci.springapps.io/api/v1/teams/java-experience/pipelines/client-certificate-mapper/jobs/deploy/badge)](https://java-experience.ci.springapps.io/teams/java-experience/pipelines/client-certificate-mapper/jobs/deploy)
+| Workflow | Status |
+| -------- | ------ |
+| CI | [![CI](https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/actions/workflows/ci.yml/badge.svg)](https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/actions/workflows/ci.yml) |
+| Release | [![Release](https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/actions/workflows/release.yml/badge.svg)](https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/actions/workflows/release.yml) |
 
-The `java-buildpack-client-certificate-mapper` is a Servlet filter that maps the `X-Forwarded-Client-Cert` to the `javax.servlet.request.X509Certificate` Servlet attribute.
+The `java-buildpack-client-certificate-mapper` is a Servlet filter that maps the `X-Forwarded-Client-Cert` header to the `javax.servlet.request.X509Certificate` (javax) or `jakarta.servlet.request.X509Certificate` (jakarta) Servlet attribute.
+
+## Download
+
+Pre-built jars are available on the [Releases page](https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/releases):
+
+- **Releases** — tagged versions (e.g. `v2.0.2`)
+- **Snapshot** — latest build from `main` (pre-release, updated on every push)
 
 ## Development
-The project depends on Java 7.  To build from source, run the following:
+
+The project requires Java 8. To build and test from source:
 
 ```shell
 $ ./mvnw clean package
 ```
+
+## CI / Workflows
+
+| Workflow | Trigger | Description |
+| -------- | ------- | ----------- |
+| **CI** | push to `main`, pull requests, manual | Builds and runs all tests. On push to `main` (after tests pass) also publishes the jar to the rolling snapshot release. |
+| **Release** | manual (`workflow_dispatch`) | Bumps to release version, tags `vX.Y.Z`, creates a GitHub Release with the jar attached, then advances to the next SNAPSHOT version. |
+
+All workflows can be triggered manually from **Actions → select workflow → Run workflow** in the GitHub UI.
 
 ## Contributing
 [Pull requests][u] and [Issues][e] are welcome.
@@ -21,6 +37,6 @@ $ ./mvnw clean package
 ## License
 This project is released under version 2.0 of the [Apache License][l].
 
-[e]: https://github.com/cloudfoundry/client-certificate-mapper/issues
+[e]: https://github.com/cloudfoundry/java-buildpack-client-certificate-mapper/issues
 [l]: https://www.apache.org/licenses/LICENSE-2.0
 [u]: https://help.github.com/articles/using-pull-requests


### PR DESCRIPTION
Closes #14

Adds GitHub Actions workflows to replace the existing Concourse CI setup:

- **CI** (`ci.yml`): runs tests on push to `main`, pull requests, and manual trigger (`workflow_dispatch`). Skips builds for changes to `.github/**`, `README.md`, `LICENSE`, `NOTICE`.
- **Snapshot** (`ci.yml`, second job): publishes a rolling `snapshot` pre-release artifact after tests pass on `main`.
- **Release** (`release.yml`): manually triggered; bumps version, commits, tags, builds, attaches jar + sources to a GitHub Release, then sets the next SNAPSHOT version and pushes.

Builds use Java 21 (required by `jakarta.servlet-api` 6.x) with source/target compatibility kept at Java 8 in the pom.

Note: `ci/promote-to-maven-central.sh` uses `concourse-release-scripts.jar` which is Concourse-specific — Maven Central publishing is not included and should be discussed separately (see #14).